### PR TITLE
Use per-package PkgEval report link

### DIFF
--- a/src/PkgDashboards.jl
+++ b/src/PkgDashboards.jl
@@ -125,7 +125,7 @@ end
 function create_entry(user, name, url; output = :markdown, autoopen=false, stargazers=false, githubci=false, stars=true, activity=false)
     entry = ["[$(user)/$(name)]($(url))",
     "[![Build Status](https://travis-ci.org/$(user)/$(name).jl.svg?branch=master)](https://travis-ci.org/$(user)/$(name).jl)",
-    "[![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/$(first(name))/$(name).svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html)",
+    "[![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/$(first(name))/$(name).svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/$(first(name))/$(name).html)",
     "[![codecov](https://codecov.io/gh/$(user)/$(name).jl/branch/master/graph/badge.svg)](https://codecov.io/gh/$(user)/$(name).jl)"]
     if stars
         push!(entry, "[![Stars](https://img.shields.io/github/stars/$(user)/$(name).jl.svg)](https://github.com/$(user)/$(name).jl/stargazers)")


### PR DESCRIPTION
We can now use per-package link like

```md
[pkgeval-img]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.svg
[pkgeval-url]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.html

[![PkgEval][pkgeval-img]][pkgeval-url]
```

[pkgeval-img]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.svg
[pkgeval-url]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/E/Example.html

[![PkgEval][pkgeval-img]][pkgeval-url]

Ref:
https://github.com/JuliaCI/NanosoldierReports/issues/5
https://github.com/JuliaCI/NanosoldierReports/commit/fceda203d80cd83559a2bb294ccb730663a049f2